### PR TITLE
fix(deps): override tmp to clear advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "static-site",
-  "version": "1.0.0",
+  "name": "readme-generator",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "static-site",
-      "version": "1.0.0",
-      "license": "ISC",
+      "name": "readme-generator",
+      "version": "2.0.0",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",
         "inquirer": "8.2.4"
@@ -467,15 +467,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -607,15 +598,12 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
   "dependencies": {
     "chalk": "^5.6.2",
     "inquirer": "8.2.4"
+  },
+  "overrides": {
+    "tmp": "^0.2.7"
   }
 }


### PR DESCRIPTION
## What
`npm audit` flagged a **high** (plus 2 low) via `inquirer@8.2.4 → external-editor@3.1.0 → tmp@0.0.33` — GHSA-52f5-9888-hmc6 / GHSA-ph9p-34f9-6g65 (path traversal).

The newest `external-editor` (3.1.0) still pins `tmp@^0.0.33`, so bumping inquirer doesn't resolve it and `npm audit fix --force` would churn the pinned inquirer for nothing. Instead, added an npm `override` forcing `tmp` to `^0.2.7`.

## Result
- `tmp` resolves to `0.2.7`; `npm audit` → **0 vulnerabilities**.
- inquirer stays pinned at `8.2.4`; CLI verified to still load and render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)