### PR TITLE
fix: consume Separator dividers correctly so the CLI launches (#35)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import inquirer from "inquirer";
 import fs from "fs/promises";
+import { pathToFileURL } from "url";
 import { generateMarkdown } from "./utils/generateMarkdown.js";
 
 // ─── Brand ───────────────────────────────────────────────────────────────────
@@ -207,10 +208,36 @@ async function writeReadme(content) {
 
 // ─── Init ─────────────────────────────────────────────────────────────────────
 
+// inquirer.Separator is only valid inside a prompt's `choices` — passing one as
+// a top-level question throws "You must provide a `name` parameter". So we walk
+// the list, print each separator as a section divider, and prompt the real
+// questions in between. Accumulated answers are threaded through so `when`
+// conditions still resolve.
+export async function promptInSections(items) {
+  const answers = {};
+  let batch = [];
+  const flush = async () => {
+    if (batch.length) {
+      Object.assign(answers, await inquirer.prompt(batch, answers));
+      batch = [];
+    }
+  };
+  for (const item of items) {
+    if (item instanceof inquirer.Separator) {
+      await flush();
+      console.log(item.line);
+    } else {
+      batch.push(item);
+    }
+  }
+  await flush();
+  return answers;
+}
+
 async function init() {
   try {
     banner();
-    const data    = await inquirer.prompt(questions);
+    const data    = await promptInSections(questions);
     const content = generateMarkdown(data);
     await writeReadme(content);
   } catch (error) {
@@ -223,4 +250,8 @@ async function init() {
   }
 }
 
-init();
+// Only run the interactive flow when executed directly (`node index.js`),
+// so the module can be imported for testing without launching prompts.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  init();
+}


### PR DESCRIPTION
Closes #35.

## Problem
`node index.js` crashed on launch with `You must provide a \`name\` parameter` — the section dividers (`inquirer.Separator`) were placed as top-level questions, which inquirer rejects (Separator is only valid inside `choices`). The CLI has been unrunnable since the #29 overhaul.

## Fix
- `promptInSections()` walks the question list: prints each `Separator.line` as a divider and batches the real questions between dividers into `inquirer.prompt` calls, threading accumulated answers so `when` conditions still resolve. Dividers are preserved exactly as designed.
- Added a direct-execution main-guard so `init()` only runs under `node index.js`, making the module importable/testable.

## Verification
- Before: immediate crash before any prompt. After: banner → `── PROJECT ──` divider → prompts render.
- Unit-tested the real `promptInSections` against a mocked inquirer: dividers print in order, questions batch correctly between separators, `when` resolves within a batch (`features` kept when its toggle is true) and skips correctly (`roadmap` dropped when its toggle is false).
- `node --check index.js` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)