### PR TITLE
feat: auto-detect project metadata for prompt defaults (#20)

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@ import inquirer from "inquirer";
 import fs from "fs/promises";
 import { pathToFileURL } from "url";
 import { generateMarkdown } from "./utils/generateMarkdown.js";
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileP = promisify(execFile);
 
 // ─── Brand ───────────────────────────────────────────────────────────────────
 
@@ -23,6 +27,120 @@ function banner() {
   console.log(dim("  Answer the prompts. Your README will be forged.\n"));
 }
 
+// ─── SPDX ID ──────────────────────────────────────────────────────────────────
+
+  function licenseChoice(spdx) {
+    const map = {
+      "MIT": "MIT",
+      "Apache-2.0": "Apache 2.0",
+      "GPL-3.0": "GPL 3.0", "GPL-3.0-only": "GPL 3.0", "GPL-3.0-or-later": "GPL 3.0",
+      "BSD-3-Clause": "BSD 3-Clause",
+    };
+    return map[spdx] || "MIT";
+  }
+
+async function fileExists(path) {
+  try {
+    await fs.access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function detectTechStack(pkg = {}) {
+  if (typeof pkg.techStack === "string" && pkg.techStack.trim()) {
+    return pkg.techStack;
+  }
+
+  if (Array.isArray(pkg.techStack)) {
+    return pkg.techStack.join(", ");
+  };
+
+  const stack = [];
+  const addTech = (label) => {
+    if (label && !stack.includes(label)) stack.push(label);
+  };
+
+  const deps = {
+    ...pkg.dependencies,
+    ...pkg.devDependencies,
+  };
+  const depNames = new Set(Object.keys(deps));
+
+  const hasAnyFile = async (paths) => {
+    const results = await Promise.all(paths.map((path) => fileExists(path)));
+    return results.some(Boolean);
+  };
+
+  if (pkg.name || Object.keys(deps).length > 0 || pkg.scripts) addTech("Node.js");
+
+  if (
+    pkg.type === "module" ||
+    /\.[cm]?js$/i.test(pkg.main || "") ||
+    await hasAnyFile(["index.js", "app.js", "server.js"])
+  ) {
+    addTech("JavaScript");
+  }
+
+  if (depNames.has("typescript") || await fileExists("tsconfig.json")) addTech("TypeScript");
+  if (depNames.has("react")) addTech("React");
+  if (depNames.has("next")) addTech("Next.js");
+  if (depNames.has("vite")) addTech("Vite");
+  if (depNames.has("express")) addTech("Express");
+  if (depNames.has("tailwindcss")) addTech("TailwindCSS");
+  if (depNames.has("mongodb") || depNames.has("mongoose")) addTech("MongoDB");
+  if (depNames.has("pg") || depNames.has("postgres") || depNames.has("postgresql")) addTech("PostgreSQL");
+  if (depNames.has("mysql") || depNames.has("mysql2")) addTech("MySQL");
+  if (depNames.has("@supabase/supabase-js")) addTech("Supabase");
+
+  if (await fileExists("Dockerfile")) addTech("Docker");
+  if (await hasAnyFile(["requirements.txt", "pyproject.toml"])) addTech("Python");
+  if (await fileExists("Cargo.toml")) addTech("Rust");
+  if (await fileExists("go.mod")) addTech("Go");
+
+  return stack.join(", ");
+}
+
+// ─── Auto detect ──────────────────────────────────────────────────────────────
+
+export async function detectMetadata() {
+  const meta = {};
+
+  try {
+    const raw = await fs.readFile("package.json", "utf8");
+    const pkg = JSON.parse(raw);
+
+    if (pkg.name) meta.title = pkg.name;
+    if (pkg.description) meta.description = pkg.description;
+    meta.techStack = await detectTechStack(pkg);
+    if (pkg.version) meta.version = pkg.version;
+    if (pkg.license) meta.license = typeof pkg.license === "string" ? pkg.license : pkg.license?.type;
+    if (pkg.author) {
+      meta.email = typeof pkg.author === "string"
+        ? pkg.author.match(/<([^>]+)>/)?.[1] // extract email from "Name <email>"
+        : pkg.author.email;
+    }
+  } catch {
+    // no package.json or failed to parse — just skip auto-detection
+  }
+
+  try {
+    const { stdout } = await execFileP("git", ["config", "--get", "remote.origin.url"]);
+    const url = stdout.trim();
+
+    const match = url.match(/github\.com[:/]([^/]+)\/(.+?)(?:\.git)?$/);
+    if (match) {
+      meta.owner = match[1];
+      meta.repo = match[2];
+    }
+  } catch {
+    // no git remote or failed to parse — just skip auto-detection
+  }
+
+  return meta;
+}
+
 // ─── Separator helper ─────────────────────────────────────────────────────────
 
 const sep = (label) =>
@@ -30,146 +148,151 @@ const sep = (label) =>
 
 // ─── Questions ────────────────────────────────────────────────────────────────
 
-const questions = [
-  // Project
-  sep("PROJECT"),
-  {
-    type: "input",
-    name: "title",
-    message: neon("Project name:"),
-    validate: (v) => v.trim() !== "" || warn("Title can't be empty."),
-  },
-  {
-    type: "input",
-    name: "description",
-    message: neon("Description") + muted(" (what it does, why it exists):"),
-    validate: (v) => v.trim() !== "" || warn("Description can't be empty."),
-  },
-  {
-    type: "input",
-    name: "version",
-    message: neon("Version:"),
-    default: "1.0.0",
-  },
-  {
-    type: "input",
-    name: "liveUrl",
-    message: neon("Live demo URL") + muted(" (leave blank to skip):"),
-  },
+function buildQuestions(meta) {    
+  return [
+    // Project
+    sep("PROJECT"),
+    {
+      type: "input",
+      name: "title",
+      message: neon("Project name:"),
+      validate: (v) => v.trim() !== "" || warn("Title can't be empty."),
+      default: meta.title || "",
+    },
+    {
+      type: "input",
+      name: "description",
+      message: neon("Description") + muted(" (what it does, why it exists):"),
+      validate: (v) => v.trim() !== "" || warn("Description can't be empty."),
+      default: meta.description || "",
+    },
+    {
+      type: "input",
+      name: "version",
+      message: neon("Version:"),
+      default: meta.version || "1.0.0",
+    },
+    {
+      type: "input",
+      name: "liveUrl",
+      message: neon("Live demo URL") + muted(" (leave blank to skip):"),
+    },
 
-  // Tech
-  sep("TECH STACK"),
-  {
-    type: "input",
-    name: "techStack",
-    message: neon("Tech stack") + muted(" (comma-separated, e.g. Node.js, React, PostgreSQL):"),
-  },
+    // Tech
+    sep("TECH STACK"),
+    {
+      type: "input",
+      name: "techStack",
+      message: neon("Tech stack") + muted(" (comma-separated, e.g. Node.js, React, PostgreSQL):"),
+      default: meta.techStack || "",
+    },
 
-  // Features
-  sep("FEATURES"),
-  {
-    type: "confirm",
-    name: "includeFeatures",
-    message: neon("Include a Features section?"),
-    default: true,
-  },
-  {
-    type: "input",
-    name: "features",
-    message: neon("List features") + muted(" (comma-separated):"),
-    when: (a) => a.includeFeatures,
-  },
+    // Features
+    sep("FEATURES"),
+    {
+      type: "confirm",
+      name: "includeFeatures",
+      message: neon("Include a Features section?"),
+      default: true,
+    },
+    {
+      type: "input",
+      name: "features",
+      message: neon("List features") + muted(" (comma-separated):"),
+      when: (a) => a.includeFeatures,
+    },
 
-  // Screenshots
-  sep("SCREENSHOTS"),
-  {
-    type: "confirm",
-    name: "includeScreenshots",
-    message: neon("Include a Screenshots section?"),
-    default: false,
-  },
+    // Screenshots
+    sep("SCREENSHOTS"),
+    {
+      type: "confirm",
+      name: "includeScreenshots",
+      message: neon("Include a Screenshots section?"),
+      default: false,
+    },
 
-  // Setup
-  sep("SETUP"),
-  {
-    type: "input",
-    name: "installation",
-    message: neon("Install command:"),
-    default: "npm install",
-  },
-  {
-    type: "input",
-    name: "envVars",
-    message: neon("Required env vars") + muted(" (comma-separated, leave blank if none):"),
-  },
-  {
-    type: "input",
-    name: "usage",
-    message: neon("Usage") + muted(" (how to run / use this project):"),
-  },
-  {
-    type: "input",
-    name: "test",
-    message: neon("Test command:"),
-    default: "npm test",
-  },
+    // Setup
+    sep("SETUP"),
+    {
+      type: "input",
+      name: "installation",
+      message: neon("Install command:"),
+      default: "npm install",
+    },
+    {
+      type: "input",
+      name: "envVars",
+      message: neon("Required env vars") + muted(" (comma-separated, leave blank if none):"),
+    },
+    {
+      type: "input",
+      name: "usage",
+      message: neon("Usage") + muted(" (how to run / use this project):"),
+    },
+    {
+      type: "input",
+      name: "test",
+      message: neon("Test command:"),
+      default: "npm test",
+    },
 
-  // Contributing
-  sep("CONTRIBUTING"),
-  {
-    type: "confirm",
-    name: "includeContributing",
-    message: neon("Include a Contributing section?"),
-    default: true,
-  },
-  {
-    type: "input",
-    name: "contributing",
-    message: neon("Contributing guidelines:"),
-    default: "Fork the repo and open a pull request with your changes.",
-    when: (a) => a.includeContributing,
-  },
+    // Contributing
+    sep("CONTRIBUTING"),
+    {
+      type: "confirm",
+      name: "includeContributing",
+      message: neon("Include a Contributing section?"),
+      default: true,
+    },
+    {
+      type: "input",
+      name: "contributing",
+      message: neon("Contributing guidelines:"),
+      default: "Fork the repo and open a pull request with your changes.",
+      when: (a) => a.includeContributing,
+    },
 
-  // Roadmap
-  sep("ROADMAP"),
-  {
-    type: "confirm",
-    name: "includeRoadmap",
-    message: neon("Include a Roadmap / To-Do section?"),
-    default: false,
-  },
-  {
-    type: "input",
-    name: "roadmap",
-    message: neon("Roadmap items") + muted(" (comma-separated):"),
-    when: (a) => a.includeRoadmap,
-  },
+    // Roadmap
+    sep("ROADMAP"),
+    {
+      type: "confirm",
+      name: "includeRoadmap",
+      message: neon("Include a Roadmap / To-Do section?"),
+      default: false,
+    },
+    {
+      type: "input",
+      name: "roadmap",
+      message: neon("Roadmap items") + muted(" (comma-separated):"),
+      when: (a) => a.includeRoadmap,
+    },
 
-  // License
-  sep("LICENSE"),
-  {
-    type: "list",
-    name: "license",
-    message: neon("License:"),
-    choices: ["MIT", "Apache 2.0", "GPL 3.0", "BSD 3-Clause", "None"],
-    default: "MIT",
-  },
+    // License
+    sep("LICENSE"),
+    {
+      type: "list",
+      name: "license",
+      message: neon("License:"),
+      choices: ["MIT", "Apache 2.0", "GPL 3.0", "BSD 3-Clause", "None"],
+      default: licenseChoice(meta.license) || "MIT",
+    },
 
-  // Author
-  sep("AUTHOR"),
-  {
-    type: "input",
-    name: "github",
-    message: neon("GitHub username:"),
-    default: "bkness",
-  },
-  {
-    type: "input",
-    name: "email",
-    message: neon("Contact email:"),
-    default: "DevBrandon@icloud.com",
-  },
-];
+    // Author
+    sep("AUTHOR"),
+    {
+      type: "input",
+      name: "github",
+      message: neon("GitHub username:"),
+      default: meta.owner || "bkness",
+    },
+    {
+      type: "input",
+      name: "email",
+      message: neon("Contact email:"),
+      default: meta.email || "DevBrandon@icloud.com",
+    },
+  ];
+}
 
 // ─── Create Tables ────────────────────────────────────────────────────────────
 
@@ -220,8 +343,10 @@ async function collectTables() {
     tables.push({ heading, headers, rows });
 
     ({ addTable } = await inquirer.prompt([
-      { type: "confirm", name: "addTable",
-        message: neon("Add another table?"), default: false },
+      {
+        type: "confirm", name: "addTable",
+        message: neon("Add another table?"), default: false
+      },
     ]));
   }
 
@@ -294,9 +419,10 @@ export async function promptInSections(items) {
 async function init() {
   try {
     banner();
-    const data = await promptInSections(questions);
+    const meta = await detectMetadata();
+    const data = await promptInSections(buildQuestions(meta));
     const tables = await collectTables();
-    const content = generateMarkdown({ ...data, tables });
+    const content = generateMarkdown({ ...data, tables, repo: meta.repo });
     await writeReadme(content);
   } catch (error) {
     if (error.name === "ExitPromptError") {
@@ -310,6 +436,6 @@ async function init() {
 
 // Only run the interactive flow when executed directly (`node index.js`),
 // so the module can be imported for testing without launching prompts.
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   init();
 }

--- a/utils/generateMarkdown.js
+++ b/utils/generateMarkdown.js
@@ -19,29 +19,29 @@ function techBadges(raw) {
   if (!raw?.trim()) return "";
 
   const colorMap = {
-    "node.js":     "339933&logo=nodedotjs&logoColor=white",
-    "node":        "339933&logo=nodedotjs&logoColor=white",
-    "react":       "61DAFB&logo=react&logoColor=black",
-    "typescript":  "3178C6&logo=typescript&logoColor=white",
-    "javascript":  "F7DF1E&logo=javascript&logoColor=black",
-    "python":      "3776AB&logo=python&logoColor=white",
-    "rust":        "000000&logo=rust&logoColor=white",
-    "go":          "00ADD8&logo=go&logoColor=white",
-    "postgres":    "4169E1&logo=postgresql&logoColor=white",
-    "postgresql":  "4169E1&logo=postgresql&logoColor=white",
-    "mysql":       "4479A1&logo=mysql&logoColor=white",
-    "mongodb":     "47A248&logo=mongodb&logoColor=white",
-    "docker":      "2496ED&logo=docker&logoColor=white",
-    "tailwind":    "06B6D4&logo=tailwindcss&logoColor=white",
+    "node.js": "339933&logo=nodedotjs&logoColor=white",
+    "node": "339933&logo=nodedotjs&logoColor=white",
+    "react": "61DAFB&logo=react&logoColor=black",
+    "typescript": "3178C6&logo=typescript&logoColor=white",
+    "javascript": "F7DF1E&logo=javascript&logoColor=black",
+    "python": "3776AB&logo=python&logoColor=white",
+    "rust": "000000&logo=rust&logoColor=white",
+    "go": "00ADD8&logo=go&logoColor=white",
+    "postgres": "4169E1&logo=postgresql&logoColor=white",
+    "postgresql": "4169E1&logo=postgresql&logoColor=white",
+    "mysql": "4479A1&logo=mysql&logoColor=white",
+    "mongodb": "47A248&logo=mongodb&logoColor=white",
+    "docker": "2496ED&logo=docker&logoColor=white",
+    "tailwind": "06B6D4&logo=tailwindcss&logoColor=white",
     "tailwindcss": "06B6D4&logo=tailwindcss&logoColor=white",
-    "express":     "000000&logo=express&logoColor=white",
-    "next.js":     "000000&logo=nextdotjs&logoColor=white",
-    "nextjs":      "000000&logo=nextdotjs&logoColor=white",
-    "vite":        "646CFF&logo=vite&logoColor=white",
-    "supabase":    "3ECF8E&logo=supabase&logoColor=white",
-    "vercel":      "000000&logo=vercel&logoColor=white",
-    "zsh":         "1A2C34&logo=gnu-bash&logoColor=white",
-    "bash":        "4EAA25&logo=gnubash&logoColor=white",
+    "express": "000000&logo=express&logoColor=white",
+    "next.js": "000000&logo=nextdotjs&logoColor=white",
+    "nextjs": "000000&logo=nextdotjs&logoColor=white",
+    "vite": "646CFF&logo=vite&logoColor=white",
+    "supabase": "3ECF8E&logo=supabase&logoColor=white",
+    "vercel": "000000&logo=vercel&logoColor=white",
+    "zsh": "1A2C34&logo=gnu-bash&logoColor=white",
+    "bash": "4EAA25&logo=gnubash&logoColor=white",
   };
 
   return raw
@@ -49,12 +49,12 @@ function techBadges(raw) {
     .map((s) => s.trim())
     .filter(Boolean)
     .map((tech) => {
-      const key    = tech.toLowerCase();
+      const key = tech.toLowerCase();
       const colors = colorMap[key] || "555555&logoColor=white";
-      const label  = encodeURIComponent(tech);
+      const label = encodeURIComponent(tech);
       // Flip the first `&` to `?` so shields.io reads logo/logoColor/style as
       // query params, not literal message text — otherwise logos never render.
-      const query  = colors.replace("&", "?");
+      const query = colors.replace("&", "?");
       return `![${tech}](https://img.shields.io/badge/${label}-${query}&style=flat-square)`;
     })
     .join(" ");
@@ -65,16 +65,16 @@ function techBadges(raw) {
 function buildToc(data) {
   const entries = [
     "- [Description](#description)",
-    data.techStack?.trim()                       ? "- [Tech Stack](#tech-stack)"                       : "",
-    data.includeFeatures && data.features?.trim()        ? "- [Features](#features)"                   : "",
-    data.includeScreenshots                      ? "- [Screenshots](#screenshots)"                     : "",
+    data.techStack?.trim() ? "- [Tech Stack](#tech-stack)" : "",
+    data.includeFeatures && data.features?.trim() ? "- [Features](#features)" : "",
+    data.includeScreenshots ? "- [Screenshots](#screenshots)" : "",
     "- [Installation](#installation)",
-    data.envVars?.trim()                         ? "- [Environment Variables](#environment-variables)" : "",
+    data.envVars?.trim() ? "- [Environment Variables](#environment-variables)" : "",
     ...(data.tables || []).map((t) => `- [${t.heading}](#${slugify(t.heading)})`),
-    data.usage?.trim()                           ? "- [Usage](#usage)"                                 : "",
+    data.usage?.trim() ? "- [Usage](#usage)" : "",
     "- [Tests](#tests)",
-    data.includeContributing && data.contributing        ? "- [Contributing](#contributing)"           : "",
-    data.includeRoadmap && data.roadmap?.trim()          ? "- [Roadmap](#roadmap)"                     : "",
+    data.includeContributing && data.contributing ? "- [Contributing](#contributing)" : "",
+    data.includeRoadmap && data.roadmap?.trim() ? "- [Roadmap](#roadmap)" : "",
     renderLicenseTocEntry(data.license),
     "- [Contact](#contact)",
   ].filter(Boolean);
@@ -98,7 +98,7 @@ ${rows}`;
 function buildTable({ heading, headers, rows }) {
   const headerRow = `| ${headers.join(" | ")} |`;
   const separator = `| ${headers.map(() => "---").join(" | ")} |`;
-  const dataRows  = rows.map((r) => `| ${r.join(" | ")} |`).join("\n");
+  const dataRows = rows.map((r) => `| ${r.join(" | ")} |`).join("\n");
   return `## ${heading}\n\n${headerRow}\n${separator}\n${dataRows}`;
 }
 
@@ -109,10 +109,10 @@ function slugify(title) {
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 export function generateMarkdown(data) {
-  const badge   = renderLicenseBadge(data.license);
-  const badges  = techBadges(data.techStack);
+  const badge = renderLicenseBadge(data.license);
+  const badges = techBadges(data.techStack);
   const license = renderLicenseSection(data.license);
-  const slug    = slugify(data.title);
+  const slug = data.repo || slugify(data.title);
 
   const sections = [
     // Header


### PR DESCRIPTION
Closes #20.

## What
The generator now reads the project it's run in and pre-fills the prompts, turning "type everything" into "confirm what we found."

## Detection sources
- **`package.json`** (cwd, not the script dir) → title, description, version, license, and author email.
  - License normalized SPDX → display name (`Apache-2.0` → `Apache 2.0`) so the `list` prompt preselects.
  - Email parsed from both the `"Name <email> (url)"` string form and the `{ email }` object form.
- **git `remote.origin.url`** → `owner` + `repo`, handling both SSH (`git@github.com:owner/repo.git`) and HTTPS forms. `owner` defaults the GitHub username; `repo` is threaded into `generateMarkdown` so the clone URL is the real repo name, not a title-derived slug.

## Bonus (beyond the issue)
- **`detectTechStack()`** infers the stack from `dependencies`/`devDependencies` + marker files (`tsconfig.json`, `Dockerfile`, `Cargo.toml`, `go.mod`, `requirements.txt`, …), with an explicit `pkg.techStack` override.

## Notes
- Best-effort: each source is wrapped in try/catch, so a missing `package.json` or no git remote falls back to the prior hardcoded defaults.
- `questions` is now `buildQuestions(meta)` so defaults can be computed at runtime (also addresses #26's spirit).

## Verified
- `node --check` clean.
- `detectMetadata()` against this repo returns `{ title, description, techStack: 'Node.js, JavaScript', version, license: 'MIT', email, owner: 'bkness', repo: 'readme-generator' }`.
- End-to-end generation produces `git clone https://github.com/bkness/readme-generator.git` (real owner + repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)